### PR TITLE
13 test failure

### DIFF
--- a/rfcpy/helpers/utils.py
+++ b/rfcpy/helpers/utils.py
@@ -15,7 +15,7 @@ import requests
 from peewee import IntegrityError
 
 from rfcpy.helpers.config import Config
-from rfcpy.models import db, Data, DataIndex, create_tables
+from rfcpy.models import Data, DataIndex, create_tables, db
 
 logging.basicConfig(level=logging.INFO)
 
@@ -110,10 +110,18 @@ def strip_extensions():
     :return clean_list: generator of files with unwanted items removed
     """
     # This continually breaks as the IETF adds more file types
-    # let's look to make it find only postitives (txt) rather 
+    # let's look to make it find only postitives (txt) rather
     # parse out negatives (non-txt).
     _, _, files = next(os.walk(Config.STORAGE_PATH))
-    dirty_extensions = ["a.txt", "rfc-index.txt", ".pdf", ".ps", ".ta", ".html", ".json"]
+    dirty_extensions = [
+        "a.txt",
+        "rfc-index.txt",
+        ".pdf",
+        ".ps",
+        ".ta",
+        ".html",
+        ".json",
+    ]
     clean_list = (x for x in files if not any(xs in x for xs in dirty_extensions))
     return clean_list
 

--- a/rfcpy/rfc.py
+++ b/rfcpy/rfc.py
@@ -12,25 +12,14 @@ import sys
 from time import sleep
 
 import click
-from peewee import OperationalError, DoesNotExist, fn
+from peewee import DoesNotExist, OperationalError, fn
 
+from rfcpy.helpers.display import (Color, clear_screen, logo,
+                                   print_by_bookmark, print_by_keyword,
+                                   print_by_number, print_get_latest, prompt)
+from rfcpy.helpers.utils import (ask_user_to_update, check_last_update,
+                                 read_config, sanitize_inputs)
 from rfcpy.models import Data, DataIndex
-from rfcpy.helpers.utils import (
-    sanitize_inputs,
-    read_config,
-    check_last_update,
-    ask_user_to_update,
-)
-from rfcpy.helpers.display import (
-    print_by_number,
-    logo,
-    Color,
-    print_by_keyword,
-    print_by_bookmark,
-    print_get_latest,
-    clear_screen,
-    prompt,
-)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 $ twine upload dist/*
 """
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 NAME = "RFC.py"
 VERSION = "2020.10.1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,15 @@
 import os
-import requests
-import responses
 import shutil
 import unittest
 from datetime import datetime
+
+import requests
+import responses
 from requests.exceptions import ConnectionError, ConnectTimeout
 
-from rfcpy.helpers.utils import (
-    Config,
-    create_config,
-    update_config,
-    get_categories,
-    read_last_conf_update,
-    sanitize_inputs,
-)
+from rfcpy.helpers.utils import (Config, create_config, get_categories,
+                                 read_last_conf_update, sanitize_inputs,
+                                 update_config)
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import responses
 import shutil
 import unittest
 from datetime import datetime
-from requests import ConnectionError, ConnectTimeout
+from requests.exceptions import ConnectionError, ConnectTimeout
 
 from rfcpy.helpers.utils import (
     Config,
@@ -20,6 +20,8 @@ class TestUtils(unittest.TestCase):
     """Testing utility functions."""
 
     def setUp(self):
+        if not os.path.exists(Config.ROOT_FOLDER):
+            os.mkdir(Config.ROOT_FOLDER)
         if not os.path.exists(Config.TESTS_FOLDER):
             os.mkdir(Config.TESTS_FOLDER)
         create_config(testing=True)


### PR DESCRIPTION
#13 Fix Test Failure :bug: 
--------------------------

Tests would fail if the application had not been run initially, or if a user had deleted `~/.rfc`. 

## Fixes:

Ensure `~/.rfc` is created during testing, and if not create it. Doing so does not interfere with the initial run after the fact.